### PR TITLE
Fix workout view to reflect selected date

### DIFF
--- a/script.js
+++ b/script.js
@@ -8,7 +8,7 @@ class WorkoutTracker {
     this.data = this.loadData();
     this.today = this.getCurrentDate();
     this.selectedDate = this.today;
-    this.currentWorkout = this.getCurrentWorkoutType();
+    this.currentWorkout = this.getWorkoutTypeForDate(this.selectedDate);
 
     this.initializeEventListeners();
     this.render();
@@ -222,8 +222,8 @@ class WorkoutTracker {
 
   // UI Rendering
   render() {
-    // Update current workout type to ensure it's always current
-    this.currentWorkout = this.getCurrentWorkoutType();
+    // Update current workout type based on the selected date
+    this.currentWorkout = this.getWorkoutTypeForDate(this.selectedDate);
 
     this.renderWorkoutHistory();
     this.renderCurrentWorkoutHeader();


### PR DESCRIPTION
## Summary
- update workout initialization to derive the active workout plan from the selected date
- ensure re-renders continue to use the selected date when determining the workout plan

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e647f281748331aa18b760be5ecf9c